### PR TITLE
Add TLS configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ export type PreCompressOptions = {
 | `HTTP_OVERRIDE_ORIGIN` | Force the request origin when it is unable to retrieve from the request                                   | -          |
 | `HTTP_IDLE_TIMEOUT`    | The request timeout for the server(in seconds)                                                            | `30`       |
 | `HTTP_MAX_BODY`        | The maximum body size for the request                                                                     | `128mib`   |
+| `TLS_CERT_FILE`        | Path to the TLS certificate file (PEM). Enables HTTPS when set alongside `TLS_KEY_FILE`                   | -          |
+| `TLS_KEY_FILE`         | Path to the TLS private key file (PEM). Required with `TLS_CERT_FILE` to enable HTTPS                     | -          |
+| `TLS_CA_FILE`          | Optional path to a CA bundle file (PEM)                                                                   | -          |
+| `TLS_PASSPHRASE`       | Optional passphrase for an encrypted `TLS_KEY_FILE`                                                       | -          |
 | `WS_IDLE_TIMEOUT`      | The websocket idle timeout (in seconds)                                                                   | `120`      |
 | `WS_MAX_PAYLOAD`       | The maximum payload size for the websocket                                                                | `16mib`    |
 | `WS_NO_PING`           | Disable automatic ping response                                                                           | `false`    |

--- a/src/files/env.ts
+++ b/src/files/env.ts
@@ -18,7 +18,11 @@ type ENV_NAMES =
     | 'WS_MAX_PAYLOAD'
     | 'WS_NO_PING'
     | 'CACHE_ASSET_AGE'
-    | 'CACHE_IMMUTABLE_AGE';
+    | 'CACHE_IMMUTABLE_AGE'
+    | 'TLS_CERT_FILE'
+    | 'TLS_KEY_FILE'
+    | 'TLS_CA_FILE'
+    | 'TLS_PASSPHRASE';
 
 export function get_env(name: ENV_NAMES): string | undefined;
 export function get_env(name: ENV_NAMES, fallback: string): string;

--- a/src/files/index.ts
+++ b/src/files/index.ts
@@ -54,9 +54,33 @@ export function websocketOptions() {
     };
 }
 
+export function tlsOptions() {
+    const cert = get_env('TLS_CERT_FILE');
+    const key = get_env('TLS_KEY_FILE');
+    if (!cert || !key) {
+        if (cert || key) {
+            console.warn(
+                '[adapter-bun] TLS_CERT_FILE and TLS_KEY_FILE must both be set. TLS disabled.'
+            );
+        }
+        return {};
+    }
+    const ca = get_env('TLS_CA_FILE');
+    const passphrase = get_env('TLS_PASSPHRASE');
+    return {
+        tls: {
+            cert: Bun.file(cert),
+            key: Bun.file(key),
+            ...(ca ? { ca: Bun.file(ca) } : {}),
+            ...(passphrase ? { passphrase } : {})
+        }
+    };
+}
+
 export function serve() {
     const server = Bun.serve({
         ...serveOptions(),
+        ...tlsOptions(),
         fetch: create_fetch({
             overrideOrigin: get_env('HTTP_OVERRIDE_ORIGIN'),
             hostHeader: get_env('HTTP_HOST_HEADER'),


### PR DESCRIPTION
Hi, thanks for maintaining this adapter.  
This PR threads Bun's existing TLS options through to `Bun.serve()` via four new env vars, so the adapter can terminate HTTPS directly, for those users that want direct tls, or require tls even between a reverse proxy and the app itself for organizational or security reasons.

Setting `TLS_CERT_FILE` and `TLS_KEY_FILE` enables it. `TLS_CA_FILE` and `TLS_PASSPHRASE` cover client-CA and encrypted-key cases. If only one of cert/key is set, it warns and stays on plain HTTP, so existing deployments are unaffected.

| Name | Description |
| --- | --- |
| `TLS_CERT_FILE` | Path to the TLS certificate (PEM). Enables HTTPS with `TLS_KEY_FILE`. |
| `TLS_KEY_FILE` | Path to the TLS private key (PEM). |
| `TLS_CA_FILE` | Optional CA bundle (PEM). |
| `TLS_PASSPHRASE` | Optional passphrase for an encrypted key. |

Happy to adjust naming or scope if a different shape would fit better.
